### PR TITLE
chore: golangの依存関係を整理し、datasourceTemplateをdockerに変更

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -13,7 +13,6 @@
       "matchPackageNames": [
         "go",
         "golang",
-        "golang/go",
         "actions/setup-go"
       ],
       "addLabels": ["go-version"],
@@ -43,28 +42,22 @@
     {
       "fileMatch": ["^README\\.md$"],
       "matchStrings": ["Go (?<currentValue>\\d+\\.\\d+)以降"],
-      "depNameTemplate": "golang/go",
-      "datasourceTemplate": "github-releases",
-      "extractVersionTemplate": "^go(?<version>\\d+\\.\\d+)",
-      "versioningTemplate": "loose"
+      "depNameTemplate": "golang",
+      "datasourceTemplate": "docker"
     },
     {
       "fileMatch": ["^\\.github/workflows/.*\\.ya?ml$"],
       "matchStrings": [
         "- (?<currentValue>\\d+\\.\\d+)\\.x"
       ],
-      "depNameTemplate": "golang/go",
-      "datasourceTemplate": "github-releases",
-      "extractVersionTemplate": "^go(?<version>\\d+\\.\\d+)",
-      "versioningTemplate": "loose"
+      "depNameTemplate": "golang",
+      "datasourceTemplate": "docker"
     },
     {
       "fileMatch": ["^\\.github/pull_request_template\\.md$"],
       "matchStrings": ["Go (?<currentValue>\\d+\\.\\d+)\\+ で動作する"],
-      "depNameTemplate": "golang/go",
-      "datasourceTemplate": "github-releases",
-      "extractVersionTemplate": "^go(?<version>\\d+\\.\\d+)",
-      "versioningTemplate": "loose"
+      "depNameTemplate": "golang",
+      "datasourceTemplate": "docker"
     }
   ],
   "schedule": [


### PR DESCRIPTION
- "golang/go"を依存関係から削除し、"golang"に統一
- 各ファイルのdatasourceTemplateを"docker"に変更

## 📋 変更内容

### 変更の種類

- [x] 🐛 バグ修正
- [ ] ✨ 新機能
- [ ] 📚 ドキュメント更新
- [ ] 🔧 設定変更
- [ ] ♻️ リファクタリング
- [ ] 🧪 テスト追加/修正
- [ ] 🚀 パフォーマンス改善

### 変更の詳細
<!-- 何を変更したか、なぜ変更したかを詳しく説明してください -->

## 🧪 テスト

### 実行したテスト

- [ ] 手動テスト完了
- [ ] 自動テスト追加/更新
- [ ] Docker環境での動作確認
- [ ] ローカルのGo環境での動作確認

### テスト手順
<!-- 変更内容をテストする方法を記載してください -->

```bash
# テスト実行例
docker-compose up -d web
# ブラウザで http://localhost にアクセスして確認
```

## 📝 チェックリスト

### コード品質

- [ ] コードは既存のスタイルに従っている
- [ ] Goの構文エラーがない
- [ ] セキュリティ上の問題がない
- [ ] 不要なコメントやデバッグコードがない

### ドキュメント

- [ ] README.mdに必要な変更を反映済み
- [ ] コメントが適切に更新されている

### 互換性

- [ ] 既存の機能に影響しない
- [ ] Go 1.23+ で動作する
- [ ] 設定ファイルの形式に変更がない（破壊的変更の場合は明記）

## 🔗 関連Issue
<!-- 関連するIssueがあれば記載 -->
Fixes #(issue番号)

## 📸 スクリーンショット
<!-- UI変更がある場合はスクリーンショットを追加 -->

## 🎯 レビュー観点
<!-- レビュアーに特に注意してほしい点があれば記載 -->

## 🔄 追加情報
<!-- その他、レビュアーが知っておくべき情報があれば記載 -->
